### PR TITLE
Visibility condition on banner button

### DIFF
--- a/docs/auto/js/config-settings.js
+++ b/docs/auto/js/config-settings.js
@@ -97,6 +97,7 @@ window.settings = {
     application: '',
     extraparam: '',
     hidebanner: true,
+    hidebanner_button:false,
     color: '#CE9840',
   },
   todo: {

--- a/src/components/settings/BannerSettings.vue
+++ b/src/components/settings/BannerSettings.vue
@@ -5,9 +5,15 @@
     <div class="container">
       <div class="body">
         <div class="layout-labels-left">
-          <div class="field-item">
-            <label class="width-auto" for="banner-hidebanner">Hide banner</label>
-            <input id="banner-hidebanner" type="checkbox" v-model="settings.banner.hidebanner" />
+          <div class="layout-inline-grid-double layout-labels-left">
+            <div class="field-item">
+              <label class="width-auto" for="banner-hidebanner">Hide banner</label>
+              <input id="banner-hidebanner" type="checkbox" v-model="settings.banner.hidebanner" />
+            </div>
+            <div class="field-item">
+              <label class="width-auto" for="banner-hidebanner_button">Hide banner button</label>
+              <input id="banner-hidebanner_button" type="checkbox" v-model="settings.banner.hidebanner_button" />
+            </div>
           </div>
           <div class="field-item">
             <label class="width-auto" for="banner-background-color">Background color</label>

--- a/src/components/widgets/Banner.vue
+++ b/src/components/widgets/Banner.vue
@@ -7,7 +7,7 @@
           <h3>{{ $t("message.banner_title") }}</h3>
           <p>{{ $t("message.banner_desc") }}</p>
         </div>
-         <button v-on:click="openBanner()">{{ $t("message.banner_action") }}</button>
+         <button v-if="settings.banner.hidebanner_button != true"  v-on:click="openBanner()">{{ $t("message.banner_action") }}</button>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Use case:
We display the list of claims on the to-do widget in account page. As claims section is the most commonly visited screen for insurance, we need it in the account page.
Also, we need a banner to be shown at the top of account page, describing the status change of a claim request. We don't need a request assistance button here, as the claim details are populated in the below to-do widget. So, we need a way to hide the button.

Changes made:
Added a flag in the settings page - Hide banner button
Based on this flag we either display or hide the banner button
