### PR TITLE
Login fields are of different width

### DIFF
--- a/src/css/_controls.css
+++ b/src/css/_controls.css
@@ -323,6 +323,11 @@ button.simple:hover {
   width: 100%;
 }
 
+.overlay select,
+.overlay input {
+  width: 100%;
+}
+
 .field > * {
   margin-top: 5rem;
 }


### PR DESCRIPTION
On clicking on Login, the username, password and signin button are of different width.
Added changes so that these 3 fields occupy same width.
These changes only reflect when overlay class is used
Before:
![Before](https://user-images.githubusercontent.com/22269847/100980769-c2bef780-356b-11eb-9504-6aeec31f9cf1.png)
After:
![after](https://user-images.githubusercontent.com/22269847/100980759-c0f53400-356b-11eb-850b-3c12d92c9e34.png)

