### PR TITLE
Hide quick links for certain users

### DIFF
--- a/docs/auto/js/config-settings.js
+++ b/docs/auto/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/commercial_bank/js/config-settings.js
+++ b/docs/commercial_bank/js/config-settings.js
@@ -54,6 +54,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -72,6 +73,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -90,6 +92,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -108,6 +111,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -126,6 +130,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/comms/js/config-settings.js
+++ b/docs/comms/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/gov/js/config-settings.js
+++ b/docs/gov/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/health_care/js/config-settings.js
+++ b/docs/health_care/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/health_payer/js/config-settings.js
+++ b/docs/health_payer/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/health_pharma/js/config-settings.js
+++ b/docs/health_pharma/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/health_provider/js/config-settings.js
+++ b/docs/health_provider/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/insurance/js/config-settings.js
+++ b/docs/insurance/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -138,6 +143,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -155,6 +161,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
 
     {
@@ -173,6 +180,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -190,6 +198,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -207,6 +216,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/manufacturing/js/config-settings.js
+++ b/docs/manufacturing/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/docs/retail_bank/js/config-settings.js
+++ b/docs/retail_bank/js/config-settings.js
@@ -54,6 +54,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -72,6 +73,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -90,6 +92,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -108,6 +111,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -126,6 +130,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/auto/js/config-settings.js
+++ b/public/auto/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/commercial_bank/js/config-settings.js
+++ b/public/commercial_bank/js/config-settings.js
@@ -54,6 +54,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -72,6 +73,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -90,6 +92,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -108,6 +111,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -126,6 +130,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/comms/js/config-settings.js
+++ b/public/comms/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/gov/js/config-settings.js
+++ b/public/gov/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/health_care/js/config-settings.js
+++ b/public/health_care/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/health_payer/js/config-settings.js
+++ b/public/health_payer/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/health_pharma/js/config-settings.js
+++ b/public/health_pharma/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/health_provider/js/config-settings.js
+++ b/public/health_provider/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/insurance/js/config-settings.js
+++ b/public/insurance/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -138,6 +143,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -155,6 +161,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
 
     {
@@ -173,6 +180,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -190,6 +198,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -207,6 +216,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/manufacturing/js/config-settings.js
+++ b/public/manufacturing/js/config-settings.js
@@ -53,6 +53,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -70,6 +71,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -87,6 +89,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -104,6 +107,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -121,6 +125,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/public/retail_bank/js/config-settings.js
+++ b/public/retail_bank/js/config-settings.js
@@ -54,6 +54,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -72,6 +73,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -90,6 +92,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -108,6 +111,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
     {
       title: {
@@ -126,6 +130,7 @@ window.settings = {
       channelid: '',
       tenantid: '',
       dataretained: true,
+      hideusers:'',
     },
   ],
   billpay: {

--- a/src/components/phone/QuickLinks.vue
+++ b/src/components/phone/QuickLinks.vue
@@ -39,7 +39,7 @@ export default {
     visibleQuickLinks() {
       return this.settings.quicklinks.filter((item, index) => {
         item.originalIndex = index;
-        return item.hide !== true;
+        return item.hide !== true && (this.settings.quicklinks[index].hideusers) ? (!this.settings.quicklinks[index].hideusers.split(',').includes(this.settings.users[mainconfig.userId].username)) : true;
       });
     },
   },

--- a/src/components/settings/QuickLinksSettings.vue
+++ b/src/components/settings/QuickLinksSettings.vue
@@ -80,6 +80,10 @@
             <label :for="'quicklinks-' + index + '-icon'">Icon (for mobile)</label>
             <input :id="'quicklinks-' + index + '-icon'" type="text" v-model="item.icon" />
           </div>
+          <div class="field-item">
+            <label :for="'quicklinks-' + index + '-hideusers'">Hide for below users (for example User1,User2)</label>
+            <input :id="'quicklinks-' + index + '-hideusers'" type="text" v-model="item.hideusers" />
+          </div>
         </div>
         <div class="layout-labels-top">
           <div class="field-item">

--- a/src/components/widgets/QuickLinks.vue
+++ b/src/components/widgets/QuickLinks.vue
@@ -4,7 +4,7 @@
     <nav>
       <ul class="quick-links">
         <li v-for="(item, index) in settings.quicklinks" :key="index">
-          <a v-if="item.hide !== true" v-on:click="selectLink(index)">{{
+          <a v-if="item.hide !== true && showQuickLink(index)" v-on:click="selectLink(index)">{{
             settings.quicklinks[index].title[currentLocale]
           }}</a>
         </li>
@@ -44,6 +44,9 @@ export default {
         if (this.settings.quicklinks[i].hide !== true) return true;
       }
       return false;
+    },
+    showQuickLink(index) {
+      return (this.settings.quicklinks[index].hideusers) ? (!this.settings.quicklinks[index].hideusers.split(',').includes(this.settings.users[mainconfig.userId].username)) : true;
     },
   },
 };


### PR DESCRIPTION
In Insurance demo use case, we have two contacts - one having personal auto and other has whole life.
Certain service cases like policy loan , surrender policy should only be displayed to whole life users and service cases like add driver, auto claim should only be displayed to personal auto users.

To fix this, I have added a field "Hide for users" in quick link settings to capture the list of users in comma separated format.
In file quicklinks.vue , added logic to hide the quick link if the current logged user is present in "hide for users" field.

Added hideusers field in all config settings.