### PR TITLE
US-704191: enabled private session control for uplus page settings

### DIFF
--- a/public/auto/js/config-settings.js
+++ b/public/auto/js/config-settings.js
@@ -482,6 +482,7 @@ window.settings = {
     DMMID: 'pega-wm-chat',
     DMMSecret: '',
     DMMPrivateURL: 'https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com',
+    UsePrivateSessionControl: false,
     DMMProactiveChatNewSessionTimeout: 0,
     DMMProactiveChatNewSessionCode: '5sonPage',
   },

--- a/public/commercial_bank/js/config-settings.js
+++ b/public/commercial_bank/js/config-settings.js
@@ -481,6 +481,7 @@ window.settings = {
     DMMID: "pega-wm-chat",
     DMMSecret: "",
     DMMPrivateURL: "https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com",
+    UsePrivateSessionControl: false,
     DMMProactiveChatNewSessionTimeout: 0,
     DMMProactiveChatNewSessionCode: '5sonPage',
   },

--- a/public/comms/js/config-settings.js
+++ b/public/comms/js/config-settings.js
@@ -489,6 +489,7 @@ window.settings = {
     DMMID: 'pega-wm-chat',
     DMMSecret: '',
     DMMPrivateURL: 'https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com',
+    UsePrivateSessionControl: false,
     DMMProactiveChatNewSessionTimeout: 0,
     DMMProactiveChatNewSessionCode: '5sonPage',
   },

--- a/public/energy/js/config-settings.js
+++ b/public/energy/js/config-settings.js
@@ -545,6 +545,7 @@ window.settings = {
 		DMMID: "pega-wm-chat",
 		DMMSecret: '',
 		DMMPrivateURL: "https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com",
+		UsePrivateSessionControl: false,
 		DMMProactiveChatNewSessionTimeout: 0,
 		DMMProactiveChatNewSessionCode: '5sonPage',
 	},

--- a/public/retail_bank/js/config-settings.js
+++ b/public/retail_bank/js/config-settings.js
@@ -550,6 +550,7 @@ window.settings = {
     DMMID: "pega-wm-chat",
     DMMSecret: "",
     DMMPrivateURL: "https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com",
+    UsePrivateSessionControl: false,
     DMMProactiveChatNewSessionTimeout: 0,
     DMMProactiveChatNewSessionCode: '5sonPage',
   },

--- a/public/wealth/js/config-settings.js
+++ b/public/wealth/js/config-settings.js
@@ -490,6 +490,7 @@ window.settings = {
     DMMID: "pega-wm-chat",
     DMMSecret: "",
     DMMPrivateURL: "https://5vtgqfsgzb.execute-api.us-east-1.amazonaws.com",
+    UsePrivateSessionControl: false,
     DMMProactiveChatNewSessionTimeout: 0,
     DMMProactiveChatNewSessionCode: '5sonPage',
   },

--- a/src/components/settings/ChatSettings.vue
+++ b/src/components/settings/ChatSettings.vue
@@ -48,6 +48,14 @@
             v-model="settings.pega_chat.DMMPrivateURL"
           />
         </div>
+        <div class="field-item field-checkbox">
+          <input
+            id="chat-UsePrivateSessionControl"
+            type="checkbox"
+            v-model="settings.pega_chat.UsePrivateSessionControl"
+          />
+          <label for="chat-UsePrivateSessionControl">Use Private Session Control</label>
+        </div>
       </div>
     </Container>
 

--- a/src/components/widgets/OperatorButton.vue
+++ b/src/components/widgets/OperatorButton.vue
@@ -114,6 +114,7 @@ export default {
       setCookie('UserID', window.PegaCSWSS.UserID, 30);
       if (
         mainconfig.settings.pega_chat.DMMSecret !== '' &&
+        mainconfig.settings.pega_chat.UsePrivateSessionControl !== false &&
         mainconfig.userId !== -1 &&
         window.PegaCSWSS.DMMSessionID !== ''
       ) {


### PR DESCRIPTION
- Added onCreateSessionRequest handler in src/global.js: Request session creation from DMS /create endpoint. Sign JWT with iss = widgetId. Return sessionId to widget.
- Updateed onSessionInitialized to persist sessionId into localStorage.
- UsePrivateSessionControl = true in config-settings.js: Post private data to configured private endpoint (iss = sessionId). Use persisted sessionId for custom event acknowledgements.
- The mock of this can be find here https://github.com/user-attachments/assets/58c999de-d650-4c3d-8896-e724d8f7cb1f