### PR TITLE
Clickthrough mashup

### DIFF
--- a/src/components/accounts/AccountPage.vue
+++ b/src/components/accounts/AccountPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="form flex flex-col">
-    <MainHeader />
+    <MainHeader v-if="!isInIframe && !isMashupOnly" />
     <main v-if="offerURL !== ''" class="flex flex-col">
       <div class="flex wrap height-100-pct"><MicroSiteMainArea /></div>
     </main>
@@ -32,7 +32,7 @@
     <main v-else class="mashup-main flex flex-col">
       <MashupMainArea class="wrap"/>
     </main>
-    <MainFooter />
+    <MainFooter v-if="!isInIframe && !isMashupOnly" />
   </div>
 </template>
 
@@ -60,6 +60,14 @@ export default {
     MainFooter,
     MicroSiteMainArea,
     RTSOverlay,
+  },
+  computed: {
+    isInIframe() {
+      return window.self !== window.top;
+    },
+    isMashupOnly() {
+      return new URLSearchParams(window.location.search).get('mashupOnly') === 'true';
+    },
   },
   methods: {
     showUserName() {

--- a/src/global.js
+++ b/src/global.js
@@ -489,7 +489,8 @@ if (typeof window.settings === 'undefined') {
     typeof mainconfigTmp.settings.pega_chat !== 'undefined' &&
     mainconfigTmp.settings.pega_chat.DMMURL !== '' &&
     mainconfigTmp.settings.pega_chat.DMMID !== '' &&
-    `${window.location}`.indexOf('/settings.html') === -1
+    `${window.location}`.indexOf('/settings.html') === -1 &&
+    window.self === window.top
   ) {
     if (typeof window.PegaUnifiedChatWidget === 'undefined') {
       window.PegaUnifiedChatWidget = {};

--- a/src/views/FrontPage.vue
+++ b/src/views/FrontPage.vue
@@ -1,28 +1,28 @@
 <template>
   <div v-if="homeHeroAction == 1 || viewKMHelp == 1" class="form flex flex-col">
-    <MainHeader />
+    <MainHeader v-if="!isInIframe" />
     <main class="mashup-main flex flex-col">
         <MashupMainArea class="wrap"/>
     </main>
-    <MainFooter />
+    <MainFooter v-if="!isInIframe" />
   </div>
   <div v-else-if="offerURL !== ''" class="form flex flex-col">
-    <MainHeader />
+    <MainHeader v-if="!isInIframe" />
     <main class="flex flex-col">
       <div class="wrap height-100-pct">
         <MicroSiteMainArea />
       </div>
     </main>
-    <MainFooter />
+    <MainFooter v-if="!isInIframe" />
   </div>
   <div v-else class="front">
     <RTSOverlay v-if="settings.pega_marketing.enableRTS" />
-    <MainHeader />
+    <MainHeader v-if="!isInIframe" />
     <main :class="'flex flex-col' + (isRTSEnabled ? ' rts-enabled' : '')">
       <FrontMainArea />
       <FrontSecondaryArea />
     </main>
-    <MainFooter />
+    <MainFooter v-if="!isInIframe" />
   </div>
 </template>
 
@@ -39,6 +39,11 @@ import RTSOverlay from '@/components/controls/RTSOverlay.vue';
 export default {
   data() {
     return mainconfig;
+  },
+  computed: {
+    isInIframe() {
+      return window.self !== window.top;
+    },
   },
   components: {
     MainHeader,


### PR DESCRIPTION
This is to address the issue that when customer clicks on an CDH offer's "Learn More" and the ClickThroughURL is something like /uplus-wss/retail_bank/?pega_userid=NA&quicklinkclass=Service-Work-SchedulePaymentPlan, there will be double loaded header and footer in the mashup
<img width="1881" height="1007" alt="wss_issue" src="https://github.com/user-attachments/assets/f9cb1b1a-5239-4d5f-8ec3-6b7bb04538b5" />
